### PR TITLE
Update checkout action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write   # required for PyPI Trusted Publishing (OIDC) — no API token needed
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
Updates the existing CI and release-publishing checkout steps to actions/checkout v7. This is the exact two-line maintenance change from conflicted Dependabot PR #16, refreshed on the protected post-v0.1.0 main. No package or release metadata changes.