### PR TITLE
docs: add CITATION.cff and align company positioning

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "zer0dex: a human-readable memory index paired with local semantic retrieval for long-running agents"
+abstract: "zer0dex gives a long-running agent local recall without forcing every detail into its prompt by pairing a small, human-readable memory index with semantic retrieval from a local vector store. The markdown layer keeps categories, durable summaries, and cross-topic pointers; the local mem0/Chroma layer holds the retrievable details. The package supplies the CLI and local server; wiring the query into model calls remains an agent-host step."
+type: software
+authors:
+  - family-names: "Bosch Rodriguez"
+    given-names: "Rolando"
+    orcid: "https://orcid.org/0009-0005-4896-1112"
+    affiliation: "Hermes Labs"
+license: Apache-2.0
+repository-code: "https://github.com/hermes-labs-ai/zer0dex"
+version: "0.1.0"
+keywords:
+  - "agent memory"
+  - "semantic retrieval"
+  - "local vector store"
+  - "mem0"
+  - "ChromaDB"

--- a/README.md
+++ b/README.md
@@ -148,5 +148,5 @@ Apache-2.0. zer0dex uses [mem0](https://mem0.ai/) for the memory abstraction,
 [Chroma](https://www.trychroma.com/) for local vector storage, and
 [Ollama](https://ollama.com/) for local embedding and extraction models.
 
-zer0dex is maintained by [Hermes Labs](https://hermes-labs.ai/), an independent
-AI reliability research lab.
+zer0dex is maintained by [Hermes Labs](https://hermes-labs.ai/), an AI reliability
+engineering studio for teams shipping production agents and LLM applications.


### PR DESCRIPTION
Two changes.

**1. Adds `CITATION.cff`** — `version: 0.1.0` (matching live PyPI), Apache-2.0, house author/ORCID block. Valid YAML, no duplicate keys, `type: software`.

**2. Company positioning.** The credits line described Hermes Labs as "an independent AI reliability research lab." The current description, per hermes-labs.ai, is an AI reliability engineering studio. This is the same correction already applied across the other repos in this pass.

The mem0 / Chroma / Ollama credit sentence above it is untouched.