### PR TITLE
build: require chromadb 1.5.9 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "mem0ai>=0.1.0",
-    "chromadb>=1.0.0",
+    "chromadb>=1.5.9",
     "ollama>=0.3.0",
 ]
 


### PR DESCRIPTION
## What changed

- raise the ChromaDB minimum from 1.0.0 to 1.5.9

## Why

Dependabot PR #10 conflicts with current `main`. A controlled compatibility check showed that both versions preserved zer0dex behavior, but ChromaDB 1.0.0 emitted repeated broken telemetry-client errors under the resolved dependency set while 1.5.9 completed cleanly.

## Validation

- ChromaDB 1.0.0: 55 tests and vector-store smoke passed, with repeated telemetry-client errors
- ChromaDB 1.5.9: `pip check`, 55 tests, package build, and telemetry-disabled vector-store smoke passed cleanly
- one-line dependency diff against current `main`
- Hermes Gate: `NOT_CONFIGURED` (repository was not implicitly onboarded)

Replaces stale Dependabot PR #10.
