### PR TITLE
build: upgrade setuptools and finish PEP 639 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ where = ["src"]
 "" = "src"
 
 [build-system]
-requires = ["setuptools>=68.0"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "zer0dex"
 version = "0.1.0"
 description = "Developer-preview local memory for AI agents: a readable index plus vector retrieval."
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [
     {name = "Rolando Bosch"},


### PR DESCRIPTION
Supersedes stale Dependabot PR #21 on current main. Raises the isolated build floor to setuptools 83 and completes the associated PEP 639 license migration, removing the deprecation scheduled to become unsupported in 2027.\n\nCompatibility: setuptools 83 supports Python >=3.10 while zer0dex requires >=3.11. Fresh Python 3.11 verification: 55 tests passed and sdist/wheel build succeeded without the prior license-table warning. Independent sterile Claude review returned PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project licensing metadata for improved standards compliance.
  * Raised the minimum required build tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->