### PR TITLE
fix(server): reject non-object JSON bodies

### DIFF
--- a/src/zer0dex/server.py
+++ b/src/zer0dex/server.py
@@ -11,9 +11,9 @@ Endpoints:
 Usage:
   python server.py [--port 18420] [--collection my_agent] [--chroma-path ./.mem0_chroma]
 """
+
 import argparse
 import json
-import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from mem0 import Memory
@@ -82,6 +82,9 @@ class Mem0Handler(BaseHTTPRequestHandler):
         if data is None:
             self._send_json({"error": "invalid json"}, 400)
             return
+        if not isinstance(data, dict):
+            self._send_json({"error": "json body must be an object"}, 400)
+            return
 
         if self.path == "/query":
             text = data.get("text", "")
@@ -96,10 +99,12 @@ class Mem0Handler(BaseHTTPRequestHandler):
             for mem in results.get("results", []):
                 score = mem.get("score", 0)
                 if score > min_score:
-                    memories.append({
-                        "text": mem.get("memory", ""),
-                        "score": round(score, 3),
-                    })
+                    memories.append(
+                        {
+                            "text": mem.get("memory", ""),
+                            "score": round(score, 3),
+                        }
+                    )
             self._send_json({"memories": memories})
 
         elif self.path == "/add":
@@ -109,10 +114,12 @@ class Mem0Handler(BaseHTTPRequestHandler):
                 return
             result = self.memory.add(text, user_id=self.user_id)
             extracted = result.get("results", [])
-            self._send_json({
-                "count": len(extracted),
-                "memories": [m.get("memory", "") for m in extracted],
-            })
+            self._send_json(
+                {
+                    "count": len(extracted),
+                    "memories": [m.get("memory", "") for m in extracted],
+                }
+            )
 
         else:
             self._send_json({"error": "not found"}, 404)
@@ -120,14 +127,28 @@ class Mem0Handler(BaseHTTPRequestHandler):
 
 def main():
     parser = argparse.ArgumentParser(description="zer0dex Memory Server")
-    parser.add_argument("--port", type=int, default=18420, help="Server port (default: 18420)")
-    parser.add_argument("--collection", default="zer0dex", help="ChromaDB collection name")
-    parser.add_argument("--chroma-path", default=".zer0dex", help="ChromaDB storage path")
+    parser.add_argument(
+        "--port", type=int, default=18420, help="Server port (default: 18420)"
+    )
+    parser.add_argument(
+        "--collection", default="zer0dex", help="ChromaDB collection name"
+    )
+    parser.add_argument(
+        "--chroma-path", default=".zer0dex", help="ChromaDB storage path"
+    )
     parser.add_argument("--user-id", default="agent", help="mem0 user ID")
-    parser.add_argument("--llm-model", default="mistral:7b", help="Ollama LLM model for extraction")
-    parser.add_argument("--embed-model", default="nomic-embed-text", help="Ollama embedding model")
-    parser.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
-    parser.add_argument("--min-score", type=float, default=0.3, help="Minimum relevance score")
+    parser.add_argument(
+        "--llm-model", default="mistral:7b", help="Ollama LLM model for extraction"
+    )
+    parser.add_argument(
+        "--embed-model", default="nomic-embed-text", help="Ollama embedding model"
+    )
+    parser.add_argument(
+        "--ollama-url", default="http://localhost:11434", help="Ollama base URL"
+    )
+    parser.add_argument(
+        "--min-score", type=float, default=0.3, help="Minimum relevance score"
+    )
     args = parser.parse_args()
 
     config = build_config(args)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,10 @@
 """Tests for zer0dex server — handler logic without requiring mem0/Ollama."""
+
 import json
 import sys
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
@@ -28,13 +27,13 @@ def make_handler(method, path, body=None):
     else:
         body_bytes = b""
 
-    raw_request = f"{method} {path} HTTP/1.1\r\nContent-Length: {len(body_bytes)}\r\nContent-Type: application/json\r\n\r\n"
-    request_data = raw_request.encode() + body_bytes
-
     handler = Mem0Handler.__new__(Mem0Handler)
     handler.rfile = BytesIO(body_bytes)
     handler.wfile = BytesIO()
-    handler.headers = {"Content-Length": str(len(body_bytes)), "Content-Type": "application/json"}
+    handler.headers = {
+        "Content-Length": str(len(body_bytes)),
+        "Content-Type": "application/json",
+    }
     handler.path = path
     handler.requestline = f"{method} {path} HTTP/1.1"
     handler.request_version = "HTTP/1.1"
@@ -45,8 +44,6 @@ def make_handler(method, path, body=None):
     handler._response_code = None
     handler._response_headers = {}
     handler._response_body = None
-
-    original_send_json = Mem0Handler._send_json.__get__(handler, Mem0Handler)
 
     def capture_send_json(data, status=200):
         handler._response_code = status
@@ -86,7 +83,9 @@ class TestHealthEndpoint:
     def test_health_returns_ok(self):
         handler = make_handler("GET", "/health")
         mock_memory = MagicMock()
-        mock_memory.get_all.return_value = {"results": [{"memory": "a"}, {"memory": "b"}]}
+        mock_memory.get_all.return_value = {
+            "results": [{"memory": "a"}, {"memory": "b"}]
+        }
         handler.memory = mock_memory
         handler.user_id = "agent"
 
@@ -187,3 +186,17 @@ class TestAddEndpoint:
 
         handler.do_POST()
         assert handler._response_code == 400
+
+    def test_non_object_json_body_returns_400(self):
+        # Valid JSON, but not an object: goes through the real _read_body.
+        handler = make_handler("POST", "/add")
+        handler.headers = {"Content-Length": "2", "Content-Type": "application/json"}
+        handler.rfile = BytesIO(b"[]")
+        handler.path = "/add"
+        handler.memory = MagicMock()
+        handler.user_id = "agent"
+
+        handler.do_POST()
+        assert handler._response_code == 400
+        assert handler._response_body == {"error": "json body must be an object"}
+        handler.memory.add.assert_not_called()


### PR DESCRIPTION
## Summary\n- return HTTP 400 for JSON request bodies that are not objects\n- prevent attribute errors from malformed client input\n- expand server regression coverage\n\n## Validation\n- all 13 server tests passed\n- Ruff and formatting checks passed\n- wheel build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with JSON bodies that are not objects now receive a clear 400 error response.
  * Invalid JSON request bodies no longer trigger memory updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->