### PR TITLE
feat: add safe background server stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ zer0dex serve --background
 zer0dex query "Where does Project Atlas deploy?"
 zer0dex add "Project Atlas deploys from the release branch"
 zer0dex status
+zer0dex stop
 ```
 
 This creates `.zer0dex.json` and a local `.zer0dex/` store in the working
-directory. Stop the background server using your operating system's process
-controls when finished.
+directory. Background starts also record their project-local process state as
+`server.json` in the configured storage directory; use `zer0dex stop` to stop
+that managed server. It will refuse to signal a PID unless the server proves
+its per-launch identity, so stale or reused state cannot stop an unrelated
+process.
 
 ## Integration surface
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,7 @@ store.
 zer0dex init [--collection NAME] [--chroma-path PATH] [--port PORT] [--user-id ID]
 zer0dex seed --source FILE_OR_DIRECTORY [--source MORE] [--dry-run]
 zer0dex serve [--port PORT] [--background]
+zer0dex stop
 zer0dex status [--port PORT]
 zer0dex query TEXT [--limit N] [--port PORT]
 zer0dex add TEXT [--port PORT]
@@ -48,7 +49,16 @@ zer0dex add TEXT [--port PORT]
 - `serve` loads the configured store and starts the loopback HTTP server.
   Foreground mode returns its server exit code. `--background` waits up to 30
   seconds for `/health`; it prints success only after that check passes, and
-  exits 1 (terminating the child) when readiness is not reached.
+  exits 1 (terminating and reaping the child) when readiness is not reached. A
+  background start writes `server.json` in the configured storage directory
+  with a per-launch identity token, and reports success only after the new
+  server proves both its token and PID.
+- `stop` stops the background server recorded by this project. Before sending
+  `SIGTERM`, it asks the loopback server on the recorded port to prove the
+  per-launch token and PID. Missing or dead state is removed safely; an
+  unverifiable, mismatched, or reused PID is never signaled and causes exit 1
+  with state preserved for inspection. Repeating `stop` after a successful
+  stop is a successful no-op.
 - `status`, `query`, and `add` require a running local server. They exit 1
   when it cannot be reached. `query` exits 0 with `No relevant memories found.`
   when the server returns an empty result set. `query --limit` requires a
@@ -72,6 +82,7 @@ zer0dex serve --port 18429 --background
 zer0dex status --port 18429
 zer0dex query 'What reply style is preferred?' --port 18429
 zer0dex add 'The demo service is local-only.' --port 18429
+zer0dex stop
 ```
 
 This is a local implementation pattern, not a guarantee of complete recall or

--- a/src/zer0dex/cli.py
+++ b/src/zer0dex/cli.py
@@ -6,15 +6,20 @@ Commands:
   zer0dex init     Initialize a new zer0dex memory store
   zer0dex seed     Seed vector store from markdown files
   zer0dex serve    Start the memory server
+  zer0dex stop     Stop this project's managed background server
   zer0dex query    Query memories from the command line
   zer0dex status   Check server health and memory count
   zer0dex add      Add a memory manually
 """
 import argparse
 import json
+import os
+import secrets
+import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.request
 import urllib.error
@@ -62,8 +67,8 @@ def port_is_in_use(port):
         return False
 
 
-def wait_for_server(port, process, timeout_seconds=30):
-    """Wait for a background server to answer health checks before reporting it ready."""
+def wait_for_server(port, process, token=None, timeout_seconds=30):
+    """Wait for the spawned server to answer health and identity checks."""
     url = f"http://127.0.0.1:{port}/health"
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -73,15 +78,125 @@ def wait_for_server(port, process, timeout_seconds=30):
         try:
             response = urllib.request.urlopen(url, timeout=1)
             payload = json.loads(response.read())
-            if payload.get("status") == "ok":
+            if payload.get("status") == "ok" and (
+                token is None or managed_server_pid(port, token) == process.pid
+            ):
                 return True
-        except (urllib.error.URLError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError):
             pass
         time.sleep(0.2)
 
-    process.terminate()
     print(f"Error: zer0dex server did not become ready within {timeout_seconds} seconds.")
     return False
+
+
+def server_state_file(config=None):
+    """Return the lifecycle state path for this project's configured store."""
+    config = load_config() if config is None else config
+    return Path(config.get("chroma_path", DEFAULT_CHROMA_PATH)) / "server.json"
+
+
+def load_server_state(config=None):
+    """Return the background-server state, or None when it is absent or invalid."""
+    state_file = server_state_file(config)
+    try:
+        state = json.loads(state_file.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(state, dict):
+        return None
+    if (
+        not isinstance(state.get("pid"), int)
+        or isinstance(state["pid"], bool)
+        or state["pid"] < 1
+    ):
+        return None
+    if not isinstance(state.get("token"), str) or not state["token"]:
+        return None
+    if (
+        not isinstance(state.get("port"), int)
+        or isinstance(state["port"], bool)
+        or not 1 <= state["port"] <= 65535
+    ):
+        return None
+    return state
+
+
+def save_server_state(pid, token, port, config=None):
+    """Record the exact background child that this project started."""
+    state_file = server_state_file(config)
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=state_file.parent,
+            prefix=f".{state_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(
+                json.dumps({"pid": pid, "token": token, "port": port}) + "\n"
+            )
+            temporary = Path(handle.name)
+        temporary.replace(state_file)
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def clear_server_state(config=None):
+    """Remove a stale local server record without touching any process."""
+    try:
+        server_state_file(config).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def managed_server_pid(port, token):
+    """Return the PID from a background server that proves the launch token."""
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/_lifecycle",
+        headers={"X-Zer0dex-Instance-Token": token},
+    )
+    try:
+        response = urllib.request.urlopen(request, timeout=1)
+        payload = json.loads(response.read())
+    except (urllib.error.URLError, json.JSONDecodeError, OSError):
+        return None
+    pid = payload.get("pid") if isinstance(payload, dict) else None
+    return pid if isinstance(pid, int) and pid > 0 else None
+
+
+def is_managed_server_process(state):
+    """Confirm PID ownership through the server's per-launch token handshake."""
+    return managed_server_pid(state["port"], state["token"]) == state["pid"]
+
+
+def process_is_running(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def terminate_spawned_process(process):
+    """Stop and reap a child that failed background startup."""
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
 
 
 def load_config():
@@ -111,11 +226,11 @@ def cmd_init(args):
     save_config(config)
     Path(config["chroma_path"]).mkdir(parents=True, exist_ok=True)
 
-    print(f"✅ zer0dex initialized")
+    print("✅ zer0dex initialized")
     print(f"   Collection: {config['collection']}")
     print(f"   Storage: {config['chroma_path']}")
     print(f"   Config: {CONFIG_FILE}")
-    print(f"\nNext: zer0dex seed --source your-docs/")
+    print("\nNext: zer0dex seed --source your-docs/")
 
 
 def cmd_seed(args):
@@ -156,7 +271,7 @@ def cmd_seed(args):
         "vector_store": {"provider": "chroma", "config": {"collection_name": config.get("collection", DEFAULT_COLLECTION), "path": config.get("chroma_path", DEFAULT_CHROMA_PATH)}},
     }
 
-    print(f"\nLoading mem0...")
+    print("\nLoading mem0...")
     memory = Memory.from_config(mem_config)
     user_id = config.get("user_id", DEFAULT_USER_ID)
 
@@ -251,17 +366,103 @@ def cmd_serve(args):
     ]
 
     if args.background:
+        state_file = server_state_file(config)
+        state = load_server_state(config)
+        if state is not None:
+            if process_is_running(state["pid"]):
+                if is_managed_server_process(state):
+                    print(
+                        "Error: a managed zer0dex background server is already "
+                        "running; use zer0dex stop first."
+                    )
+                else:
+                    print(
+                        "Error: the recorded background PID is running but its "
+                        "identity cannot be verified; refusing to replace its state."
+                    )
+                sys.exit(1)
+            clear_server_state(config)
+        elif state_file.exists():
+            clear_server_state(config)
         if port_is_in_use(port):
             print(f"Error: port {port} is already in use; no server was started.")
             sys.exit(1)
-        proc = subprocess.Popen(server_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        if not wait_for_server(port, proc):
+        token = secrets.token_urlsafe(24)
+        proc = subprocess.Popen(
+            server_args + ["--instance-token", token],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            save_server_state(proc.pid, token, port, config)
+        except OSError as exc:
+            terminate_spawned_process(proc)
+            print(f"Error: could not record background server state: {exc}")
+            sys.exit(1)
+        try:
+            ready = wait_for_server(port, proc, token)
+        except BaseException:
+            terminate_spawned_process(proc)
+            clear_server_state(config)
+            raise
+        if not ready:
+            terminate_spawned_process(proc)
+            clear_server_state(config)
             sys.exit(1)
         print(f"✅ zer0dex server started (PID {proc.pid}, port {port})")
     else:
         result = subprocess.run(server_args)
         if result.returncode:
             sys.exit(result.returncode)
+
+
+def cmd_stop(args):
+    """Stop the background server started by this project, if it still matches state."""
+    config = load_config()
+    state_file = server_state_file(config)
+    state = load_server_state(config)
+    if state is None:
+        if state_file.exists():
+            clear_server_state(config)
+            print("Removed invalid stale zer0dex background server state.")
+            return
+        print("No managed zer0dex background server is running.")
+        return
+
+    pid = state["pid"]
+    if not process_is_running(pid):
+        clear_server_state(config)
+        print("Removed stale zer0dex background server state.")
+        return
+
+    if not is_managed_server_process(state):
+        print(
+            "Error: refusing to signal the recorded PID because the server identity "
+            "could not be verified; state was kept for inspection."
+        )
+        sys.exit(1)
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        clear_server_state(config)
+        print("Removed stale zer0dex background server state.")
+        return
+    except PermissionError:
+        print(f"Error: permission denied while stopping zer0dex server PID {pid}; state was kept.")
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Error: could not stop zer0dex server PID {pid}: {exc}; state was kept.")
+        sys.exit(1)
+    deadline = time.monotonic() + 5
+    while process_is_running(pid) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if process_is_running(pid):
+        print(f"Error: zer0dex server PID {pid} did not stop; state was kept.")
+        sys.exit(1)
+
+    clear_server_state(config)
+    print(f"✅ zer0dex server stopped (PID {pid}).")
 
 
 def cmd_query(args):
@@ -354,6 +555,9 @@ def main():
     p_serve.add_argument("--port", type=int, help="Server port")
     p_serve.add_argument("--background", "-b", action="store_true", help="Run in background")
 
+    # stop
+    sub.add_parser("stop", help="Stop the project-managed background server")
+
     # query
     p_query = sub.add_parser("query", help="Query memories")
     p_query.add_argument("text", help="Query text")
@@ -379,6 +583,7 @@ def main():
         "init": cmd_init,
         "seed": cmd_seed,
         "serve": cmd_serve,
+        "stop": cmd_stop,
         "query": cmd_query,
         "status": cmd_status,
         "add": cmd_add,

--- a/src/zer0dex/seed.py
+++ b/src/zer0dex/seed.py
@@ -7,7 +7,6 @@ Usage:
   python seed.py --source MEMORY.md --source memory/ [--collection my_agent] [--chroma-path ./.mem0_chroma]
 """
 import argparse
-import os
 import sys
 from pathlib import Path
 

--- a/src/zer0dex/server.py
+++ b/src/zer0dex/server.py
@@ -14,6 +14,8 @@ Usage:
 import argparse
 import json
 from numbers import Real
+import os
+import secrets
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
@@ -55,6 +57,7 @@ class Mem0Handler(BaseHTTPRequestHandler):
     memory = None
     user_id = None
     min_score = 0.3
+    instance_token = None
 
     def log_message(self, format, *args):
         pass  # suppress request logging
@@ -80,6 +83,14 @@ class Mem0Handler(BaseHTTPRequestHandler):
             all_mem = get_all_for_user(self.memory, self.user_id)
             count = len(all_mem.get("results", []))
             self._send_json({"status": "ok", "count": count})
+        elif self.path == "/_lifecycle":
+            token = self.headers.get("X-Zer0dex-Instance-Token", "")
+            if not self.instance_token or not secrets.compare_digest(
+                token, self.instance_token
+            ):
+                self._send_json({"error": "not found"}, 404)
+                return
+            self._send_json({"pid": os.getpid()})
         else:
             self._send_json({"error": "not found"}, 404)
 
@@ -143,6 +154,7 @@ def main():
     parser.add_argument("--embed-model", default="nomic-embed-text", help="Ollama embedding model")
     parser.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
     parser.add_argument("--min-score", type=float, default=0.3, help="Minimum relevance score")
+    parser.add_argument("--instance-token", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     if Memory is None:
@@ -173,6 +185,7 @@ def main():
     Mem0Handler.memory = memory
     Mem0Handler.user_id = args.user_id
     Mem0Handler.min_score = args.min_score
+    Mem0Handler.instance_token = args.instance_token
 
     server = HTTPServer(("127.0.0.1", args.port), Mem0Handler)
     try:

--- a/src/zer0dex/server.py
+++ b/src/zer0dex/server.py
@@ -86,7 +86,7 @@ class Mem0Handler(BaseHTTPRequestHandler):
         elif self.path == "/_lifecycle":
             token = self.headers.get("X-Zer0dex-Instance-Token", "")
             if not self.instance_token or not secrets.compare_digest(
-                token, self.instance_token
+                token.encode("utf-8"), self.instance_token.encode("utf-8")
             ):
                 self._send_json({"error": "not found"}, 404)
                 return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,14 +7,13 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from zer0dex import cli
-from zer0dex.cli import load_config, positive_int, save_config, main
+from zer0dex.cli import load_config, positive_int, save_config
 from zer0dex.server import Mem0Handler
 
 
@@ -76,7 +75,7 @@ class TestCLIParsing:
             cwd=str(Path(__file__).resolve().parent.parent),
             env={**__import__("os").environ, "PYTHONPATH": str(Path(__file__).resolve().parent.parent / "src")},
         )
-        for cmd in ["check", "init", "seed", "serve", "query", "status", "add"]:
+        for cmd in ["check", "init", "seed", "serve", "stop", "query", "status", "add"]:
             assert cmd in result.stdout, f"Missing command: {cmd}"
 
 
@@ -181,30 +180,121 @@ class TestRuntimePrerequisites:
 
         assert exit_info.value.code == 7
 
-    def test_background_serve_waits_for_readiness(self, monkeypatch, capsys):
+    def test_background_serve_waits_for_readiness(self, tmp_workdir, monkeypatch, capsys):
         process = SimpleNamespace(pid=123, poll=lambda: None)
         monkeypatch.setattr(cli, "require_ollama_client", lambda: True)
         monkeypatch.setattr(cli, "load_config", lambda: {})
         monkeypatch.setattr(cli, "port_is_in_use", lambda port: False)
         monkeypatch.setattr(cli.subprocess, "Popen", lambda *args, **kwargs: process)
-        monkeypatch.setattr(cli, "wait_for_server", lambda port, process: True)
+        monkeypatch.setattr(cli, "wait_for_server", lambda port, process, token: True)
 
         cli.cmd_serve(SimpleNamespace(port=None, background=True))
 
         assert "server started (PID 123, port 18420)" in capsys.readouterr().out
+        state = json.loads((tmp_workdir / ".zer0dex" / "server.json").read_text())
+        assert state["pid"] == 123
+        assert state["port"] == 18420
+        assert state["token"]
 
-    def test_background_serve_fails_when_not_ready(self, monkeypatch):
-        process = SimpleNamespace(pid=123, poll=lambda: None)
+    def test_background_serve_fails_when_not_ready(self, tmp_workdir, monkeypatch):
+        calls = []
+        process = SimpleNamespace(
+            pid=123,
+            poll=lambda: None,
+            terminate=lambda: calls.append("terminate"),
+            wait=lambda timeout=None: calls.append(("wait", timeout)),
+        )
         monkeypatch.setattr(cli, "require_ollama_client", lambda: True)
         monkeypatch.setattr(cli, "load_config", lambda: {})
         monkeypatch.setattr(cli, "port_is_in_use", lambda port: False)
         monkeypatch.setattr(cli.subprocess, "Popen", lambda *args, **kwargs: process)
-        monkeypatch.setattr(cli, "wait_for_server", lambda port, process: False)
+        monkeypatch.setattr(cli, "wait_for_server", lambda port, process, token: False)
 
         with pytest.raises(SystemExit) as exit_info:
             cli.cmd_serve(SimpleNamespace(port=None, background=True))
 
         assert exit_info.value.code == 1
+        assert calls == ["terminate", ("wait", 5)]
+        assert not cli.server_state_file().exists()
+
+    def test_stop_terminates_verified_background_server(self, tmp_workdir, monkeypatch, capsys):
+        cli.save_server_state(123, "launch-token", 18420)
+        checks = iter([True, False, False])
+        signal_calls = []
+        monkeypatch.setattr(cli, "process_is_running", lambda pid: next(checks))
+        monkeypatch.setattr(cli, "is_managed_server_process", lambda state: True)
+        monkeypatch.setattr(cli.os, "kill", lambda pid, sig: signal_calls.append((pid, sig)))
+
+        cli.cmd_stop(SimpleNamespace())
+
+        assert signal_calls == [(123, cli.signal.SIGTERM)]
+        assert not (tmp_workdir / ".zer0dex" / "server.json").exists()
+        assert "server stopped (PID 123)" in capsys.readouterr().out
+
+    def test_stop_cleans_dead_server_state(self, tmp_workdir, monkeypatch, capsys):
+        cli.save_server_state(123, "launch-token", 18420)
+        monkeypatch.setattr(cli, "process_is_running", lambda pid: False)
+
+        cli.cmd_stop(SimpleNamespace())
+
+        assert not (tmp_workdir / ".zer0dex" / "server.json").exists()
+        assert "Removed stale" in capsys.readouterr().out
+
+    def test_stop_refuses_reused_or_unrelated_pid(self, tmp_workdir, monkeypatch, capsys):
+        cli.save_server_state(123, "launch-token", 18420)
+        signal_calls = []
+        monkeypatch.setattr(cli, "process_is_running", lambda pid: True)
+        monkeypatch.setattr(cli, "is_managed_server_process", lambda state: False)
+        monkeypatch.setattr(cli.os, "kill", lambda pid, sig: signal_calls.append((pid, sig)))
+
+        with pytest.raises(SystemExit) as exit_info:
+            cli.cmd_stop(SimpleNamespace())
+
+        assert exit_info.value.code == 1
+        assert signal_calls == []
+        assert (tmp_workdir / ".zer0dex" / "server.json").exists()
+        assert "refusing to signal the recorded PID" in capsys.readouterr().out
+
+    def test_managed_process_identity_requires_server_and_launch_token(self, monkeypatch):
+        state = {"pid": 123, "token": "launch-token", "port": 18420}
+        monkeypatch.setattr(cli, "managed_server_pid", lambda port, token: 123)
+        assert cli.is_managed_server_process(state)
+
+        monkeypatch.setattr(cli, "managed_server_pid", lambda port, token: 456)
+        assert not cli.is_managed_server_process(state)
+
+    def test_server_state_uses_configured_storage_path(self, tmp_workdir):
+        config = {"chroma_path": "custom-memory"}
+
+        cli.save_server_state(123, "launch-token", 18420, config)
+
+        state_file = tmp_workdir / "custom-memory" / "server.json"
+        assert json.loads(state_file.read_text())["pid"] == 123
+        assert state_file.stat().st_mode & 0o777 == 0o600
+        assert not (tmp_workdir / ".zer0dex" / "server.json").exists()
+
+    def test_invalid_server_port_is_stale_state(self, tmp_workdir):
+        state_file = tmp_workdir / ".zer0dex" / "server.json"
+        state_file.parent.mkdir()
+        state_file.write_text(
+            json.dumps({"pid": 123, "token": "launch-token", "port": 70000})
+        )
+
+        assert cli.load_server_state() is None
+
+    def test_boolean_pid_is_stale_state(self, tmp_workdir):
+        state_file = tmp_workdir / ".zer0dex" / "server.json"
+        state_file.parent.mkdir()
+        state_file.write_text(
+            json.dumps({"pid": True, "token": "launch-token", "port": 18420})
+        )
+
+        assert cli.load_server_state() is None
+
+    def test_stop_is_a_successful_noop_when_repeated(self, tmp_workdir, capsys):
+        cli.cmd_stop(SimpleNamespace())
+
+        assert "No managed zer0dex background server is running" in capsys.readouterr().out
 
     def test_background_serve_rejects_an_occupied_port(self, monkeypatch, capsys):
         monkeypatch.setattr(cli, "require_ollama_client", lambda: True)

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -3,8 +3,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from zer0dex.seed import collect_files, chunk_markdown, get_all_for_user, search_for_user

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,9 +28,6 @@ def make_handler(method, path, body=None):
     else:
         body_bytes = b""
 
-    raw_request = f"{method} {path} HTTP/1.1\r\nContent-Length: {len(body_bytes)}\r\nContent-Type: application/json\r\n\r\n"
-    request_data = raw_request.encode() + body_bytes
-
     handler = Mem0Handler.__new__(Mem0Handler)
     handler.rfile = BytesIO(body_bytes)
     handler.wfile = BytesIO()
@@ -45,8 +42,6 @@ def make_handler(method, path, body=None):
     handler._response_code = None
     handler._response_headers = {}
     handler._response_body = None
-
-    original_send_json = Mem0Handler._send_json.__get__(handler, Mem0Handler)
 
     def capture_send_json(data, status=200):
         handler._response_code = status
@@ -101,6 +96,28 @@ class TestHealthEndpoint:
     def test_unknown_get_returns_404(self):
         handler = make_handler("GET", "/unknown")
         handler.do_GET()
+        assert handler._response_code == 404
+
+    def test_lifecycle_requires_exact_launch_token(self, monkeypatch):
+        handler = make_handler("GET", "/_lifecycle")
+        handler.instance_token = "launch-token"
+        handler.headers["X-Zer0dex-Instance-Token"] = "launch-token"
+        monkeypatch.setattr("zer0dex.server.os.getpid", lambda: 123)
+
+        handler.do_GET()
+
+        assert handler._response_code == 200
+        assert handler._response_body == {"pid": 123}
+
+    @pytest.mark.parametrize("token", ["", "wrong-token"])
+    def test_lifecycle_rejects_missing_or_wrong_token(self, token):
+        handler = make_handler("GET", "/_lifecycle")
+        handler.instance_token = "launch-token"
+        if token:
+            handler.headers["X-Zer0dex-Instance-Token"] = token
+
+        handler.do_GET()
+
         assert handler._response_code == 404
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -109,7 +109,7 @@ class TestHealthEndpoint:
         assert handler._response_code == 200
         assert handler._response_body == {"pid": 123}
 
-    @pytest.mark.parametrize("token", ["", "wrong-token"])
+    @pytest.mark.parametrize("token", ["", "wrong-token", "wrong-tökèn"])
     def test_lifecycle_rejects_missing_or_wrong_token(self, token):
         handler = make_handler("GET", "/_lifecycle")
         handler.instance_token = "launch-token"


### PR DESCRIPTION
## Summary

- add `zer0dex stop` for project-managed background servers
- persist lifecycle state in the configured storage directory and require an exact launch-token plus PID handshake before signaling
- clean up failed background starts, preserve unverifiable state for inspection, and make repeated stops safe
- document the lifecycle contract and add focused regression coverage
- remove the small pre-existing Python lint blockers surfaced by the quality rail

## Validation

- `python -m pytest tests/ -q` — 66 passed
- `python -m ruff check src tests` — passed
- `hermes-gate fast` — passed
- `hermes-gate review` — passed with no findings after review-driven hardening

## Safety and scope

The stop command never signals a recorded PID unless the loopback server proves the matching per-launch token and PID. The generated local Hermes Gate bootstrap is excluded from this PR. No release, tag, merge, or deployment is included.

Commit includes the required DCO sign-off. Implementation assisted by OpenAI Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `zer0dex stop` command to stop managed background servers.
  - Background servers now track project-local process state and verify server identity before starting or stopping processes.
  - Repeated stops are safe no-ops, while stale, mismatched, or unverifiable server state is preserved and reported.

- **Bug Fixes**
  - Improved startup readiness handling and cleanup when a background server fails to become ready.

- **Documentation**
  - Updated quick-start and CLI documentation with background server lifecycle and stop-command guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->