### PR TITLE
docs: expose the TypeScript host adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ The shortest host integration is an HTTP `POST /query` before each model call.
 Use the returned `memories` as additional context according to your own prompt
 and trust policy. The server also exposes `POST /add` and `GET /health`.
 
+For a TypeScript host, the repository includes a small adapter that adds a
+bounded, fail-open lookup before dispatching a model call:
+[hook_example.ts](https://github.com/hermes-labs-ai/zer0dex/blob/v0.1.1/src/zer0dex/hook_example.ts).
+Copy the `queryZer0dex` helper into your message pipeline and keep the returned
+memories in an explicitly untrusted context field. The example is deliberately
+an adapter rather than an automatic hook installer, so the host retains control
+over when retrieved text enters a prompt.
+
 Exact commands, options, response fields, errors, and compatibility promises
 live in the reference documentation:
 


### PR DESCRIPTION
## Problem
The repository ships `src/zer0dex/hook_example.ts`, but the README's integration section did not link it. Developers reaching the documented HTTP API had no direct path to the copyable TypeScript host adapter.

## Change
Link the versioned adapter from the README and explain its bounded, fail-open behavior and untrusted-context boundary.

## Validation
- `git diff --check`
- `python -m pytest tests/ -q` (67 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the README’s integration guidance with details about the included TypeScript adapter.
  - Documented bounded, fail-open lookups before model dispatch.
  - Clarified how retrieved memories should be handled as explicitly untrusted context.
  - Explained that the adapter requires manual integration, allowing hosts to control when retrieved text is added to prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->